### PR TITLE
Let's call it AsciiDoc(tor)

### DIFF
--- a/src/docs/asciidoc/02_AsciiDoctor.adoc
+++ b/src/docs/asciidoc/02_AsciiDoctor.adoc
@@ -1,4 +1,4 @@
-== Swagger und AsciiDoc
+== AsciiDoc(tor)
 
 http://asciidoctor.org/docs/asciidoc-writers-guide/[AsciiDoc] ist eine Auszeichnungssprache vergleichbar mit Markdown, allerdings deutlich umfangreicher. AsciiDoc eignet sich dafür Artikel, Bücher, Ebooks oder Slideshows zu erstellen. AsciiDoc Dateien können in mehrere Formate wie z.B. HTML, PDF, EPUB oder DocBook konvertiert werden. 
 AsciiDoc, aber auch Markdown, eignen sicher hervorragend dafür handgeschrieben Dokumentation zu erstellen.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= Dokumentation von RESTful APIs mittels Swagger und AsciiDoc
+= Dokumentation von RESTful APIs mittels Swagger und AsciiDoc(tor)
 :toc: left
 :toclevels: 4
 ':source-highlighter: coderay
@@ -6,11 +6,11 @@
 :hardbreaks:
 :pagenums:
 
-include::00_Intor.adoc[]
+include::00_Intro.adoc[]
 
 include::01_Swagger.adoc[]
 
-include::02_AsciiDoc.adoc[]
+include::02_AsciiDoctor.adoc[]
 
 include::03_Swagger2Markup.adoc[]
 


### PR DESCRIPTION
typo fix in index.adoc
renaming AsciiDoc to AsciiDoc(tor)
